### PR TITLE
alter the user message api

### DIFF
--- a/error_code.go
+++ b/error_code.go
@@ -232,7 +232,7 @@ func NewJSONFormat(errCode ErrorCode) JSONFormat {
 		stack = StackTrace(errCode)
 	}
 
-	msg := UserMsg(errCode)
+	msg := GetUserMsg(errCode)
 	if msg == "" {
 		msg = errCode.Error()
 	}


### PR DESCRIPTION
NewUserMsg -> UserMsg
UserMsg -> GetUserMsg

Add a new function WithUserMsg(string, ErrorCode)

This is a breaking change.
However, this API was just introduced,
so we will take the liberty of considering it to have been unstable.