### PR TITLE
add error wrapping conveniences

### DIFF
--- a/error_code.go
+++ b/error_code.go
@@ -151,8 +151,8 @@ func (code Code) IsAncestor(ancestorCode Code) bool {
 //		return PathBlockedCode
 //	}
 type ErrorCode interface {
-	Error() string // The Error interface
 	Code() Code
+	error
 }
 
 // unwrapper allows the abstract retrieval of the underlying error.

--- a/error_code_test.go
+++ b/error_code_test.go
@@ -180,6 +180,43 @@ func TestErrorWrapperCode(t *testing.T) {
 	ClientDataEquals(t, ErrorWrapper{Err: sconst}, sconst)
 }
 
+func TestErrorWrapperFunctions(t *testing.T) {
+	coded := errcode.NewBadRequestErr(errors.New("underlying"))
+
+	{
+		wrap := errcode.Wrap(coded, "wrapped")
+		AssertCode(t, coded, wrap.Code().CodeStr())
+		if errMsg := wrap.Error(); errMsg != "wrapped: underlying" {
+			t.Errorf("Wrap unexpected: %s", errMsg)
+		}
+		if errors.Unwrap(wrap) == coded {
+			t.Error("bad unwrap")
+		}
+	}
+
+	{
+		wrapf := errcode.Wrapf(coded, "wrapped %s", "arg")
+		AssertCode(t, coded, wrapf.Code().CodeStr())
+		if errMsg := wrapf.Error(); errMsg != "wrapped arg: underlying" {
+			t.Errorf("Wrap unexpected: %s", errMsg)
+		}
+		if errors.Unwrap(wrapf) == coded {
+			t.Error("bad unwrap")
+		}
+	}
+
+	{
+		wraps := errcode.Wraps(coded, "wrapped", "arg", 1)
+		AssertCode(t, coded, wraps.Code().CodeStr())
+		if errMsg := wraps.Error(); errMsg != "wrapped arg=1: underlying" {
+			t.Errorf("Wrap unexpected: %s", errMsg)
+		}
+		if errors.Unwrap(wraps) == coded {
+			t.Error("bad unwrap")
+		}
+	}
+}
+
 var internalChildCodeStr errcode.CodeStr = "internal.child.granchild"
 var internalChild = errcode.InternalCode.Child("internal.child").SetHTTP(503).Child(internalChildCodeStr)
 

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/gregwebs/errcode
 
 go 1.21.9
 
-require github.com/gregwebs/errors v1.0.0
+require github.com/gregwebs/errors v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/gregwebs/errors v1.0.0 h1:Ov7HzBs79i7TcqQnfxyxLT8gttpTzGT3cDq70J8zkpE=
-github.com/gregwebs/errors v1.0.0/go.mod h1:hUKQdGWTRTHMeAXJudXmN/BMLe+L51MG+OnRz72ZeBc=
+github.com/gregwebs/errors v1.2.0 h1:9QmMmbIPtgVNKEyinWD08z2brRKEf3CbWj+tRraNas0=
+github.com/gregwebs/errors v1.2.0/go.mod h1:1NkCObP7+scylHlC69lwHl2ACOHwktWYrZV4EJDEl6g=


### PR DESCRIPTION
Currently it is annoying to wrap an ErrorCode
because the type changes to error.

Add conveneince functions that keep the type as ErrorCode