### PR TITLE
use a generic wrapper interface Unwrapper

### DIFF
--- a/codes.go
+++ b/codes.go
@@ -100,7 +100,7 @@ func NewCodedError(err error, code Code) CodedError {
 
 var _ ErrorCode = (*CodedError)(nil)     // assert implements interface
 var _ HasClientData = (*CodedError)(nil) // assert implements interface
-var _ unwrapper = (*CodedError)(nil)     // assert implements interface
+var _ unwrapError = (*CodedError)(nil)   // assert implements interface
 
 func (e CodedError) Error() string {
 	return e.Err.Error()
@@ -139,7 +139,7 @@ func NewInvalidInputErr(err error) ErrorCode {
 
 var _ ErrorCode = (*invalidInputErr)(nil)     // assert implements interface
 var _ HasClientData = (*invalidInputErr)(nil) // assert implements interface
-var _ unwrapper = (*invalidInputErr)(nil)     // assert implements interface
+var _ unwrapError = (*invalidInputErr)(nil)   // assert implements interface
 
 // badReqeustErr gives the code BadRequestErr.
 type BadRequestErr struct{ CodedError }
@@ -167,7 +167,7 @@ func NewInternalErr(err error) InternalErr {
 
 var _ ErrorCode = (*InternalErr)(nil)     // assert implements interface
 var _ HasClientData = (*InternalErr)(nil) // assert implements interface
-var _ unwrapper = (*InternalErr)(nil)     // assert implements interface
+var _ unwrapError = (*InternalErr)(nil)   // assert implements interface
 
 // makeInternalStackCode builds a function for making an an internal error with a stack trace.
 func makeInternalStackCode(defaultCode Code) func(error) StackCode {
@@ -227,7 +227,7 @@ func NewNotFoundErr(err error) NotFoundErr {
 
 var _ ErrorCode = (*NotFoundErr)(nil)     // assert implements interface
 var _ HasClientData = (*NotFoundErr)(nil) // assert implements interface
-var _ unwrapper = (*NotFoundErr)(nil)     // assert implements interface
+var _ unwrapError = (*NotFoundErr)(nil)   // assert implements interface
 
 // NotAuthenticatedErr gives the code NotAuthenticatedCode.
 type NotAuthenticatedErr struct{ CodedError }
@@ -241,7 +241,7 @@ func NewNotAuthenticatedErr(err error) NotAuthenticatedErr {
 
 var _ ErrorCode = (*NotAuthenticatedErr)(nil)     // assert implements interface
 var _ HasClientData = (*NotAuthenticatedErr)(nil) // assert implements interface
-var _ unwrapper = (*NotAuthenticatedErr)(nil)     // assert implements interface
+var _ unwrapError = (*NotAuthenticatedErr)(nil)   // assert implements interface
 
 // ForbiddenErr gives the code ForbiddenCode.
 type ForbiddenErr struct{ CodedError }
@@ -255,7 +255,7 @@ func NewForbiddenErr(err error) ForbiddenErr {
 
 var _ ErrorCode = (*ForbiddenErr)(nil)     // assert implements interface
 var _ HasClientData = (*ForbiddenErr)(nil) // assert implements interface
-var _ unwrapper = (*ForbiddenErr)(nil)     // assert implements interface
+var _ unwrapError = (*ForbiddenErr)(nil)   // assert implements interface
 
 // UnprocessableErr gives the code UnprocessibleCode.
 type UnprocessableErr struct{ CodedError }

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/gregwebs/errcode
 
 go 1.21.9
 
-require github.com/gregwebs/errors v1.2.0
+require github.com/gregwebs/errors v1.5.0

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/gregwebs/errors v1.2.0 h1:9QmMmbIPtgVNKEyinWD08z2brRKEf3CbWj+tRraNas0=
-github.com/gregwebs/errors v1.2.0/go.mod h1:1NkCObP7+scylHlC69lwHl2ACOHwktWYrZV4EJDEl6g=
+github.com/gregwebs/errors v1.5.0 h1:+vMiQwtPnVVr2RuVebjVQMnMZwUPIpeTU/iXgCOFBfE=
+github.com/gregwebs/errors v1.5.0/go.mod h1:1NkCObP7+scylHlC69lwHl2ACOHwktWYrZV4EJDEl6g=

--- a/group_test.go
+++ b/group_test.go
@@ -29,6 +29,7 @@ func AssertLength[Any any](t *testing.T, slice []Any, expected int) {
 	}
 
 }
+
 func TestErrorCodes(t *testing.T) {
 	codes := errcode.ErrorCodes(nil)
 	AssertLength(t, codes, 0)

--- a/operation.go
+++ b/operation.go
@@ -35,7 +35,7 @@ func Operation(v interface{}) string {
 	if hasOp, ok := v.(HasOperation); ok {
 		return hasOp.GetOperation()
 	}
-	if un, ok := v.(unwrapper); ok {
+	if un, ok := v.(unwrapError); ok {
 		return Operation(un.Unwrap())
 	}
 	return ""
@@ -86,7 +86,7 @@ func (e OpErrCode) GetClientData() interface{} {
 var _ ErrorCode = (*OpErrCode)(nil)     // assert implements interface
 var _ HasClientData = (*OpErrCode)(nil) // assert implements interface
 var _ HasOperation = (*OpErrCode)(nil)  // assert implements interface
-var _ unwrapper = (*OpErrCode)(nil)     // assert implements interface
+var _ unwrapError = (*OpErrCode)(nil)   // assert implements interface
 
 // AddOp is constructed by Op. It allows method chaining with AddTo.
 type AddOp func(ErrorCode) OpErrCode

--- a/stack.go
+++ b/stack.go
@@ -88,4 +88,4 @@ func (e StackCode) GetClientData() interface{} {
 
 var _ ErrorCode = (*StackCode)(nil)     // assert implements interface
 var _ HasClientData = (*StackCode)(nil) // assert implements interface
-var _ unwrapper = (*StackCode)(nil)        // assert implements interface
+var _ unwrapError = (*StackCode)(nil)   // assert implements interface

--- a/user.go
+++ b/user.go
@@ -40,7 +40,7 @@ func GetUserMsg(v interface{}) string {
 	var msg string
 	if hasMsg, ok := v.(HasUserMsg); ok {
 		msg = hasMsg.GetUserMsg()
-	} else if un, ok := v.(unwrapper); ok {
+	} else if un, ok := v.(unwrapError); ok {
 		return GetUserMsg(un.Unwrap())
 	}
 	return msg
@@ -91,7 +91,7 @@ func (e UserMsgErrCode) GetClientData() interface{} {
 var _ ErrorCode = (*UserMsgErrCode)(nil)     // assert implements interface
 var _ HasClientData = (*UserMsgErrCode)(nil) // assert implements interface
 var _ HasUserMsg = (*UserMsgErrCode)(nil)    // assert implements interface
-var _ unwrapper = (*UserMsgErrCode)(nil)     // assert implements interface
+var _ unwrapError = (*UserMsgErrCode)(nil)   // assert implements interface
 
 // AddUserMsg is constructed by UserMsg. It allows method chaining with AddTo.
 type AddUserMsg func(ErrorCode) UserMsgErrCode


### PR DESCRIPTION
This should allow for a proper recovery of the original type

Upgrade the errors package for consistent behavior of Wraps