### PR TITLE
error wrapping that maintains types

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/gregwebs/errcode
 
 go 1.21.9
 
-require github.com/gregwebs/errors v1.5.0
+require github.com/gregwebs/errors v1.12.0

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/gregwebs/errors v1.5.0 h1:+vMiQwtPnVVr2RuVebjVQMnMZwUPIpeTU/iXgCOFBfE=
-github.com/gregwebs/errors v1.5.0/go.mod h1:1NkCObP7+scylHlC69lwHl2ACOHwktWYrZV4EJDEl6g=
+github.com/gregwebs/errors v1.12.0 h1:PCpiS9WUFVFA70RF+oqDN/GtdSPa+XoyzVNJqAZ99Dg=
+github.com/gregwebs/errors v1.12.0/go.mod h1:1NkCObP7+scylHlC69lwHl2ACOHwktWYrZV4EJDEl6g=

--- a/goa/goa.go
+++ b/goa/goa.go
@@ -13,13 +13,13 @@ import (
 )
 
 type ErrorCodeGoa struct {
-	errorCode errcode.ErrorCode
-	err       error
+	errcode.ErrorCode
+	err error
 }
 
 // fulfill GOA expectation
 func (ec ErrorCodeGoa) GoaErrorName() string {
-	return string(ec.errorCode.Code().CodeStr())
+	return string(ec.ErrorCode.Code().CodeStr())
 }
 
 // fulfill http.Statuser
@@ -32,10 +32,6 @@ func (ec ErrorCodeGoa) StatusCode() int {
 	return *httpCode
 }
 
-func (ec ErrorCodeGoa) Code() errcode.Code {
-	return ec.errorCode.Code()
-}
-
 func (ec ErrorCodeGoa) Error() string {
 	return ec.err.Error()
 }
@@ -45,7 +41,7 @@ func (ec ErrorCodeGoa) Unwrap() error {
 }
 
 func (ec ErrorCodeGoa) MarshalJSON() ([]byte, error) {
-	return json.Marshal(errcode.NewJSONFormat(ec.errorCode))
+	return json.Marshal(errcode.NewJSONFormat(ec.ErrorCode))
 }
 
 func AsErrorCodeGoa(err error) *ErrorCodeGoa {
@@ -57,7 +53,7 @@ func AsErrorCodeGoa(err error) *ErrorCodeGoa {
 	}
 	if errCode := errcode.CodeChain(err); errCode != nil {
 		return &ErrorCodeGoa{
-			errorCode: errCode,
+			ErrorCode: errCode,
 			err:       err,
 		}
 	}
@@ -67,7 +63,7 @@ func AsErrorCodeGoa(err error) *ErrorCodeGoa {
 
 func ErrorCodeToGoa(errCode errcode.ErrorCode) ErrorCodeGoa {
 	return ErrorCodeGoa{
-		errorCode: errCode,
+		ErrorCode: errCode,
 		err:       errCode,
 	}
 }
@@ -174,7 +170,8 @@ func ServiceErrorToErrorCode(err *goalib.ServiceError) ErrorCodeGoa {
 			errorForCode = EnumErr{err: err}
 		}
 	}
-	var errCode errcode.ErrorCode = errcode.NewCodedError(errorForCode, code)
+	coded := errcode.NewCodedError(errorForCode, code)
+	var errCode errcode.ErrorCode = &coded
 	return ErrorCodeToGoa(errCode)
 }
 

--- a/group.go
+++ b/group.go
@@ -23,6 +23,7 @@ import (
 // It first calls the Errors function.
 func ErrorCodes(err error) []ErrorCode {
 	errorCodes := make([]ErrorCode, 0)
+	//nolint:staticcheck
 	errors.WalkDeep(err, func(err error) bool {
 		if errcode, ok := err.(ErrorCode); ok {
 			// avoid duplicating codes

--- a/group_test.go
+++ b/group_test.go
@@ -51,17 +51,17 @@ func TestErrorCodeChain(t *testing.T) {
 	code := MinimalError{}
 	// AssertCodeChain(t, code, code)
 	ann := errors.Wrap(code, "added annotation")
-	AssertCodeChain(t, ann, errcode.ChainContext{Top: ann, ErrCode: code})
+	AssertCodeChain(t, ann, errcode.ChainContext{Top: ann, ErrorCode: code})
 	ann2 := errors.Wrap(ann, "another annotation")
-	AssertCodeChain(t, ann2, errcode.ChainContext{Top: ann2, ErrCode: code})
+	AssertCodeChain(t, ann2, errcode.ChainContext{Top: ann2, ErrorCode: code})
 
 	code2 := MinimalError{}
 	// horizontal composition
 	multiCode := errcode.Combine(code, code2)
 	annMultiCode := errors.Wrap(multiCode, "multi ann")
-	AssertCodeChain(t, annMultiCode, errcode.ChainContext{Top: annMultiCode, ErrCode: multiCode})
+	AssertCodeChain(t, annMultiCode, errcode.ChainContext{Top: annMultiCode, ErrorCode: multiCode})
 	multiErr := MultiErrors{Multi: []error{errors.New("ignore"), annMultiCode}}
-	AssertCodeChain(t, multiErr, errcode.ChainContext{Top: multiErr, ErrCode: errcode.ChainContext{Top: annMultiCode, ErrCode: multiCode}})
+	AssertCodeChain(t, multiErr, errcode.ChainContext{Top: multiErr, ErrorCode: errcode.ChainContext{Top: annMultiCode, ErrorCode: multiCode}})
 	// TODO: vertical composition
 }
 

--- a/grpc/grpc_test.go
+++ b/grpc/grpc_test.go
@@ -35,6 +35,10 @@ func (e GRPCError) Code() errcode.Code {
 	return codeAborted
 }
 
+func (e GRPCError) WrapError(apply func(err error) error) {
+	panic("WrapError not implemented")
+}
+
 func TestGrpcErrorCode(t *testing.T) {
 	err := GRPCError{}
 	AssertGRPCCode(t, err, codes.Aborted)

--- a/operation.go
+++ b/operation.go
@@ -54,28 +54,23 @@ func (e EmbedOp) GetOperation() string {
 // This can be conveniently constructed with Op() and AddTo() to record the operation information for the error.
 // However, it isn't required to be used, see the HasOperation documentation for alternatives.
 type OpErrCode struct {
+	ErrorCode
 	Operation string
-	Err       ErrorCode
 }
 
 // Unwrap satisfies the errors package Unwrap function
 func (e OpErrCode) Unwrap() error {
-	return e.Err
+	return e.ErrorCode
 }
 
 // Error prefixes the operation to the underlying Err Error.
 func (e OpErrCode) Error() string {
-	return e.Operation + ": " + e.Err.Error()
+	return e.Operation + ": " + e.ErrorCode.Error()
 }
 
 // GetOperation satisfies the HasOperation interface.
 func (e OpErrCode) GetOperation() string {
 	return e.Operation
-}
-
-// Code returns the underlying Code of Err.
-func (e OpErrCode) Code() Code {
-	return e.Err.Code()
 }
 
 var _ ErrorCode = (*OpErrCode)(nil)    // assert implements interface
@@ -102,6 +97,6 @@ func Op(operation string) AddOp {
 		if err == nil {
 			panic("Op error is nil")
 		}
-		return OpErrCode{Operation: operation, Err: err}
+		return OpErrCode{ErrorCode: err, Operation: operation}
 	}
 }

--- a/stack.go
+++ b/stack.go
@@ -34,7 +34,7 @@ func StackTrace(err error) errors.StackTrace {
 // Generally stack traces aren't needed for user errors, but they are provided by NewInternalErr.
 // Its also possible to define your own structures that satisfy the StackTracer interface.
 type StackCode struct {
-	Err      ErrorCode
+	ErrorCode
 	GetStack errors.StackTracer
 }
 
@@ -60,25 +60,20 @@ func NewStackCode(err ErrorCode, position ...int) StackCode {
 
 	// if there is an existing trace, take that: it should be deeper
 	if tracer := errors.GetStackTracer(err); tracer != nil {
-		return StackCode{Err: err, GetStack: tracer}
+		return StackCode{ErrorCode: err, GetStack: tracer}
 	}
 
-	return StackCode{Err: err, GetStack: errors.NewStack(stackPosition)}
+	return StackCode{ErrorCode: err, GetStack: errors.NewStack(stackPosition)}
 }
 
 // Unwrap satisfies the errors package Unwrap function
 func (e StackCode) Unwrap() error {
-	return e.Err
+	return e.ErrorCode
 }
 
 // Error ignores the stack and gives the underlying Err Error.
 func (e StackCode) Error() string {
-	return e.Err.Error()
-}
-
-// Code returns the underlying Code of Err.
-func (e StackCode) Code() Code {
-	return e.Err.Code()
+	return e.ErrorCode.Error()
 }
 
 var _ ErrorCode = (*StackCode)(nil)   // assert implements interface


### PR DESCRIPTION
This requires all ErrorCode to implement a wrap function. ErrorCodes are normally built on top of reused base types. Such as CodedError.

This change is useful with UserCode.
UserCode is useful as a return type of a function
so that a caller know there is a user message.
This allows the UserCdoe to be easily wrapped with additional information while still maintaining the UserCode type.