### PR TITLE
4error code wrapping with some generic reuse

### DIFF
--- a/error_code.go
+++ b/error_code.go
@@ -45,8 +45,6 @@ package errcode
 import (
 	"fmt"
 	"strings"
-
-	"github.com/gregwebs/errors"
 )
 
 // CodeStr is the name of the error code.
@@ -133,58 +131,6 @@ func (code Code) IsAncestor(ancestorCode Code) bool {
 type ErrorCode interface {
 	error
 	Code() Code
-	ErrorWrap
-}
-
-// The WrapError method allows for modifying the inner error while maintaining the same outer type.
-// This is most useful when wrapping an extended ErrorCode interface such as UserCode.
-// These are used by the errcode.Wrap* functions.
-type ErrorWrap interface {
-	WrapError(func(error) error)
-}
-
-// unwrapError allows the abstract retrieval of the underlying error.
-// Formalize the Unwrap interface, but don't export it.
-// The standard library errors package should export it.
-// Types that wrap errors should implement this to allow viewing of the underlying error.
-type unwrapError interface {
-	Unwrap() error
-}
-
-// Wrap calls errors.Wrap on the inner error.
-// This uses the WrapError method of ErrorWrap
-// If a nil is given it is a noop
-func Wrap(errCode ErrorWrap, msg string) {
-	if errCode == nil {
-		return
-	}
-	errCode.WrapError(func(err error) error {
-		return errors.Wrap(err, msg)
-	})
-}
-
-// Wrapf calls errors.Wrapf on the inner error.
-// This uses the WrapError method of ErrorWrap
-// If a nil is given it is a noop
-func Wrapf(errCode ErrorWrap, msg string, args ...interface{}) {
-	if errCode == nil {
-		return
-	}
-	errCode.WrapError(func(err error) error {
-		return errors.Wrapf(err, msg, args...)
-	})
-}
-
-// Wraps calls errors.Wraps on the inner error.
-// This uses the WrapError method of ErrorWrap
-// If a nil is given it is a noop
-func Wraps(errCode ErrorWrap, msg string, args ...interface{}) {
-	if errCode == nil {
-		return
-	}
-	errCode.WrapError(func(err error) error {
-		return errors.Wraps(err, msg, args...)
-	})
 }
 
 // HasClientData is used to defined how to retrieve the data portion of an ErrorCode to be returned to the client.

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/gregwebs/errcode
 
 go 1.21.9
 
-require github.com/gregwebs/errors v1.12.0
+require github.com/gregwebs/errors v1.13.3

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/gregwebs/errors v1.12.0 h1:PCpiS9WUFVFA70RF+oqDN/GtdSPa+XoyzVNJqAZ99Dg=
-github.com/gregwebs/errors v1.12.0/go.mod h1:1NkCObP7+scylHlC69lwHl2ACOHwktWYrZV4EJDEl6g=
+github.com/gregwebs/errors v1.13.3 h1:8hfIWNIU8EgCN98nzXwS690AKKRsGq2nih3PdbhWh9s=
+github.com/gregwebs/errors v1.13.3/go.mod h1:1NkCObP7+scylHlC69lwHl2ACOHwktWYrZV4EJDEl6g=

--- a/group.go
+++ b/group.go
@@ -116,10 +116,6 @@ func (e multiCode[Err]) Error() string {
 	return output
 }
 
-func (e multiCode[Err]) WrapError(apply func(err error) error) {
-	e.ErrCode.WrapError(apply)
-}
-
 // Errors fullfills the ErrorGroup inteface
 func (e multiCode[Err]) Errors() []error {
 	return append([]error{error(e.ErrCode)}, e.rest...)

--- a/wrap.go
+++ b/wrap.go
@@ -1,0 +1,134 @@
+package errcode
+
+import (
+	"github.com/gregwebs/errors"
+)
+
+// Wrap calls errors.Wrap or errors.Wrapf on the inner error.
+// This will wrap in place via errors.ErrorWrapper if available
+// If a nil is given it is a noop
+func Wrap(errCode ErrorCode, msg string, args ...interface{}) ErrorCode {
+	return wrapG(wrapWith, errCode, msg, args...)
+}
+
+// Wraps calls errors.Wraps on the inner error.
+// This will wrap in place via errors.ErrorWrapper if available
+// If a nil is given it is a noop
+func Wraps(errCode ErrorCode, msg string, args ...interface{}) ErrorCode {
+	return wrapWith(errCode, errors.WrapsFn(msg, args...))
+}
+
+// WrapUser calls errors.Wrap or errors.Wrapf on the inner error.
+// This will wrap in place via errors.ErrorWrapper if available
+// If a nil is given it is a noop
+func WrapUser(errCode UserCode, msg string, args ...interface{}) UserCode {
+	return wrapG(wrapUserWith, errCode, msg, args...)
+}
+
+// WrapsUser calls errors.Wraps on the inner error.
+// This uses the WrapError method of ErrorWrap
+// If a nil is given it is a noop
+func WrapsUser(errCode UserCode, msg string, args ...interface{}) UserCode {
+	return wrapUserWith(errCode, errors.WrapsFn(msg, args...))
+}
+
+// WrapOp calls errors.Wrap or errors.Wrapf on the inner error.
+// This will wrap in place via errors.ErrorWrapper if available
+// If a nil is given it is a noop
+func WrapOp(errCode OpCode, msg string, args ...interface{}) OpCode {
+	return wrapG(wrapOpWith, errCode, msg, args...)
+}
+
+// WrapsOp calls errors.Wraps on the inner error.
+// This uses the WrapError method of ErrorWrap
+// If a nil is given it is a noop
+func WrapsOp(errCode OpCode, msg string, args ...interface{}) OpCode {
+	return wrapOpWith(errCode, errors.WrapsFn(msg, args...))
+}
+
+func wrapWith(errCode ErrorCode, wrap func(error) error) ErrorCode {
+	if errCode == nil {
+		return errCode
+	}
+	ok := errors.WrapInPlace(errCode, wrap)
+	if ok {
+		return errCode
+	}
+	return wrappedErrorCode{newWithError(errCode, wrap)}
+}
+
+func wrapUserWith(errCode UserCode, wrap func(error) error) UserCode {
+	if errCode == nil {
+		return errCode
+	}
+	ok := errors.WrapInPlace(errCode, wrap)
+	if ok {
+		return errCode
+	}
+	return wrappedUserCode{newWithError(errCode, wrap)}
+}
+
+func wrapOpWith(errCode OpCode, wrap func(error) error) OpCode {
+	if errCode == nil {
+		return errCode
+	}
+	ok := errors.WrapInPlace(errCode, wrap)
+	if ok {
+		return errCode
+	}
+	return wrappedOpCode{newWithError(errCode, wrap)}
+}
+
+// unwrapError allows the abstract retrieval of the underlying error.
+// Formalize the Unwrap interface, but don't export it.
+// The standard library errors package should export it.
+// Types that wrap errors should implement this to allow viewing of the underlying error.
+type unwrapError interface {
+	Unwrap() error
+}
+
+type withError[T any] struct {
+	With T
+	*errors.ErrorWrap
+}
+
+// do a nil check before calling this
+func newWithError[Err error](errCode Err, wrapErr func(error) error) withError[Err] {
+	return withError[Err]{
+		With:      errCode,
+		ErrorWrap: &errors.ErrorWrap{Err: wrapErr(errCode)},
+	}
+}
+
+type wrappedErrorCode struct{ withError[ErrorCode] }
+
+func (wec wrappedErrorCode) Code() Code {
+	return wec.With.Code()
+}
+
+type wrappedUserCode struct{ withError[UserCode] }
+
+func (wec wrappedUserCode) Code() Code {
+	return wec.With.Code()
+}
+
+func (wec wrappedUserCode) GetUserMsg() string {
+	return wec.With.GetUserMsg()
+}
+
+type wrappedOpCode struct{ withError[OpCode] }
+
+func (wec wrappedOpCode) Code() Code {
+	return wec.With.Code()
+}
+
+func (wec wrappedOpCode) GetOperation() string {
+	return wec.With.GetOperation()
+}
+
+func wrapG[Err ErrorCode](errWrap func(Err, func(error) error) Err, errCode Err, msg string, args ...interface{}) Err {
+	if len(args) == 0 {
+		return errWrap(errCode, errors.WrapFn(msg))
+	}
+	return errWrap(errCode, errors.WrapfFn(msg, args...))
+}

--- a/wrap_test.go
+++ b/wrap_test.go
@@ -1,0 +1,157 @@
+package errcode_test
+
+import (
+	"testing"
+
+	"github.com/gregwebs/errcode"
+	"github.com/gregwebs/errors"
+)
+
+func TestErrorWrapperNil(t *testing.T) {
+	// Don't panic!
+	if errcode.Wrap(errcode.ErrorCode(nil), "wrapped") != nil {
+		t.Errorf("Wrap nil should be nil")
+	}
+	if errcode.Wrap(errcode.ErrorCode(nil), "wrapped") != nil {
+		t.Errorf("Wrapf nil should be nil")
+	}
+	if errcode.Wraps(errcode.ErrorCode(nil), "wrapped") != nil {
+		t.Errorf("Wraps nil should be nil")
+	}
+}
+
+func TestErrorWrapperFunctions(t *testing.T) {
+	underlying := errors.New("underlying")
+
+	{
+		bad := errcode.NewBadRequestErr(underlying)
+		AssertCode(t, bad, errcode.InvalidInputCode.CodeStr())
+		coded := errcode.Wrap(bad, "wrapped")
+		AssertCode(t, coded, errcode.InvalidInputCode.CodeStr())
+		if errMsg := coded.Error(); errMsg != "wrapped: underlying" {
+			t.Errorf("Wrap unexpected: %s", errMsg)
+		}
+		doubleUnwrap := errors.Unwrap(errors.Unwrap(coded))
+		if doubleUnwrap.Error() != underlying.Error() {
+			t.Errorf("bad unwrap: %s", doubleUnwrap.Error())
+		}
+	}
+
+	{
+		bad := errcode.NewBadRequestErr(underlying)
+		AssertCode(t, bad, errcode.InvalidInputCode.CodeStr())
+		coded := errcode.Wrap(bad, "wrapped %s", "arg")
+		AssertCode(t, coded, errcode.InvalidInputCode.CodeStr())
+		if errMsg := coded.Error(); errMsg != "wrapped arg: underlying" {
+			t.Errorf("Wrap unexpected: %s", errMsg)
+		}
+		doubleUnwrap := errors.Unwrap(errors.Unwrap(coded))
+		if doubleUnwrap.Error() != underlying.Error() {
+			t.Errorf("bad unwrap: %s", doubleUnwrap.Error())
+		}
+	}
+
+	{
+		bad := errcode.NewBadRequestErr(underlying)
+		AssertCode(t, bad, errcode.InvalidInputCode.CodeStr())
+		coded := errcode.Wraps(bad, "wrapped", "arg", 1)
+		AssertCode(t, coded, errcode.InvalidInputCode.CodeStr())
+		if errMsg := coded.Error(); errMsg != "wrapped arg=1: underlying" {
+			t.Errorf("Wrap unexpected: %s", errMsg)
+		}
+		doubleUnwrap := errors.Unwrap(errors.Unwrap(coded))
+		if doubleUnwrap.Error() != underlying.Error() {
+			t.Errorf("bad unwrap: %s", doubleUnwrap.Error())
+		}
+	}
+}
+
+func TestUserWrapperFunctions(t *testing.T) {
+	underlying := errors.New("underlying")
+
+	{
+		coded := errcode.WithUserMsg("user",
+			errcode.NewBadRequestErr(underlying),
+		)
+		AssertCode(t, coded, errcode.InvalidInputCode.CodeStr())
+		coded = errcode.WrapUser(coded, "wrapped")
+		AssertCode(t, coded, errcode.InvalidInputCode.CodeStr())
+		if errMsg := coded.Error(); errMsg != "user: wrapped: underlying" {
+			t.Errorf("Wrap unexpected: %s", errMsg)
+		}
+		tripleUnwrap := errors.Unwrap(errors.Unwrap(errors.Unwrap(coded)))
+		if tripleUnwrap.Error() != underlying.Error() {
+			t.Errorf("bad unwrap: %s", tripleUnwrap.Error())
+		}
+	}
+
+	{
+		coded := errcode.WithUserMsg("user",
+			errcode.NewBadRequestErr(underlying),
+		)
+		AssertCode(t, coded, errcode.InvalidInputCode.CodeStr())
+		coded = errcode.WrapUser(coded, "wrapped %s", "arg")
+		AssertCode(t, coded, errcode.InvalidInputCode.CodeStr())
+		if errMsg := coded.Error(); errMsg != "user: wrapped arg: underlying" {
+			t.Errorf("Wrap unexpected: %s", errMsg)
+		}
+		tripleUnwrap := errors.Unwrap(errors.Unwrap(errors.Unwrap(coded)))
+		if tripleUnwrap.Error() != underlying.Error() {
+			t.Errorf("bad unwrap: %s", tripleUnwrap.Error())
+		}
+	}
+
+	{
+		coded := errcode.WithUserMsg("user",
+			errcode.NewBadRequestErr(underlying),
+		)
+		AssertCode(t, coded, errcode.InvalidInputCode.CodeStr())
+		coded = errcode.WrapsUser(coded, "wrapped", "arg", 1)
+		AssertCode(t, coded, errcode.InvalidInputCode.CodeStr())
+		if errMsg := coded.Error(); errMsg != "user: wrapped arg=1: underlying" {
+			t.Errorf("Wrap unexpected: %s", errMsg)
+		}
+		tripleUnwrap := errors.Unwrap(errors.Unwrap(errors.Unwrap(coded)))
+		if tripleUnwrap.Error() != underlying.Error() {
+			t.Errorf("bad unwrap: %s", tripleUnwrap.Error())
+		}
+	}
+}
+
+func TestManyWrappings(t *testing.T) {
+	underlying := errors.New("underlying")
+
+	{
+		user := errcode.WithUserMsg("user",
+			errcode.NewBadRequestErr(underlying),
+		)
+		opCode := errcode.Op("op").AddTo(user)
+		AssertCode(t, opCode, errcode.InvalidInputCode.CodeStr())
+		coded := errcode.WrapOp(opCode, "wrapped")
+		AssertCode(t, coded, errcode.InvalidInputCode.CodeStr())
+		if errMsg := coded.Error(); errMsg != "op: user: wrapped: underlying" {
+			t.Errorf("Wrap unexpected: %s", errMsg)
+		}
+		tripleUnwrap := errors.Unwrap(errors.Unwrap(errors.Unwrap(errors.Unwrap(coded))))
+		if tripleUnwrap.Error() != underlying.Error() {
+			t.Errorf("bad unwrap: %s", tripleUnwrap.Error())
+		}
+	}
+}
+
+func TestWrapNotInPlace(t *testing.T) {
+	user := errcode.WithUserMsg("user",
+		MinimalError{},
+	)
+	op := errcode.Op("op").AddTo(user)
+	AssertCode(t, op, codeString)
+	coded := errcode.Wrap(op, "wrapped")
+	AssertCode(t, coded, codeString)
+	if errMsg := coded.Error(); errMsg != "wrapped: op: user: error" {
+		t.Errorf("Wrap unexpected: %s", errMsg)
+	}
+	tripleUnwrap := errors.Unwrap(errors.Unwrap(errors.Unwrap(errors.Unwrap(coded))))
+	if tripleUnwrap.Error() != (MinimalError{}).Error() {
+		t.Errorf("bad unwrap: %s", tripleUnwrap.Error())
+	}
+}


### PR DESCRIPTION
The goal is to wrap an ErrorCode
while maintaining its type.
This allows for using UserCode as a marke type
that a user message will be returned
and still allows for wrapping the error
with extra information.

In-place modification accomplishes this,
and will be used if available (via ErrorWrapper)
However, requiring this in the ErrorCode interface is too burdensome.
Instead fallback to a wrapper type
that will be different per-interface.
There are different wrapping functions for each interface to maintain the type and not downcast to ErrorCode.